### PR TITLE
Adding image interface layer and pinging versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy
-scipy
-scikit-image
-tifffile
-PyWavelets
-tqdm
-pathlib2
-dcimg
+numpy==1.19.5
+scipy==1.5.4
+scikit-image==0.17.2
+tifffile==2020.9.3
+PyWavelets==1.1.1
+tqdm==4.64.1
+pathlib2==2.3.7.post1
+dcimg==0.6.0.post1

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        "numpy",
-        "scipy",
-        "scikit-image",
-        "tifffile",
-        "PyWavelets",
-        "tqdm",
-        "pathlib2",
-        "dcimg"
+        "numpy==1.19.5",
+        "scipy==1.5.4",
+        "scikit-image==0.17.2",
+        "tifffile==2020.9.3",
+        "PyWavelets==1.1.1",
+        "tqdm==4.64.1",
+        "pathlib2==2.3.7.post1",
+        "dcimg==0.6.0.post1"
     ],
     author="LifeCanvas Technologies",
     packages=["pystripe"],


### PR DESCRIPTION
Hello @joegruss,

There are a couple of important things to mention to make `Pystripe` work properly. The original pystripe version was intended to work with `python 3.6` and the latest packages were [following](https://github.com/camilolaiton/pystripe/blob/feat-image-interface/requirements.txt). The issue with the `.png` images in `bit8` instead of `bit16` is related to using `imageio.imwrite()` with a different version than `2.15.0` which was the latest for `python 3.6` and I'll go a little bit in detail here.

The [latest pypi publication of `imageio`](https://pypi.org/project/imageio/) has two different versions, the [v3](https://github.com/imageio/imageio/blob/master/imageio/v3.py) and [v2](https://github.com/imageio/imageio/blob/master/imageio/v2.py) and by default `imageio.imwrite` is pointed to the `v2` version which has a [bug for writing bit16 images](https://github.com/imageio/imageio/issues/352) where low saturation images were directly saved as `bit8` instead of `bit16` (By default, they use the `pillow` plugin to write the images, if you guys are curious). However, if [we specify the `v3` version in the code](https://github.com/camilolaiton/pystripe/blob/feat-image-interface-py38/pystripe/core.py#L173) this issue dissapears. Therefore, my guess with the reported issue is that for some reason `imageio` was installed in a different version from `2.15.0`.

Following up with these changes, this branch was created by using this [commit](https://github.com/LifeCanvas-Technologies/pystripe/tree/7954253f0bc909775636d2f894d1e62bd9007d06) which was the one right before #1 was merged to main. This PR has the changes to include the image interface feature and I changed the following:

1. np.float to float since this was deprecated in the numpy version 1.20. This is only an alias numpy for float as they are completely [identical](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations).
![np float and float](https://user-images.githubusercontent.com/36769694/230230130-e96ce78e-6532-4205-8a96-be02dfd4ed99.png)

2. I set the versions in the `requirements.txt` and `setup.py` to avoid versioning issues.

3. I added the `output_format` parameter in pystripe which receives the following formats: `.tiff`, `.tif` and `.png`. If no format is specified, then the default output is `.tiff`.
![png_to_tiffs](https://user-images.githubusercontent.com/36769694/230230287-0e9fb090-1fd7-4970-b200-9238666c4e3d.png)
![png_to_png_3_6](https://user-images.githubusercontent.com/36769694/230232686-dc9765b9-e3a7-4c7c-9e85-16407fd93aff.png)

Additionally, I feel is important that we move this package to work with a higher python version since in our team we have some packages using pystripe in a `python 3.8` environment. That is why I created another [branch](https://github.com/camilolaiton/pystripe/tree/feat-image-interface-py38). **Please, consider this version and test it before merging this PR.** Here are some screenshots of this version working:

![png_to_png_3_8](https://user-images.githubusercontent.com/36769694/230232534-a3f51f07-3562-4908-946a-7ea714426ab2.png)

![png_to_tiff_3_8](https://user-images.githubusercontent.com/36769694/230232571-8768c356-db5c-4bbc-b571-50819151feeb.png)

